### PR TITLE
Fix logic issue with Mario Wings to the Sky not requiring cannon.

### DIFF
--- a/docs/changelogs/1.2.1.json
+++ b/docs/changelogs/1.2.1.json
@@ -1,0 +1,3 @@
+[
+    "Fix logic issue with Mario Wings to the Sky not requiring cannon."
+]

--- a/pack_root/manifest.json
+++ b/pack_root/manifest.json
@@ -3,7 +3,7 @@
     "platform": "pc",
     "game_name": "Super Mario 64",
     "package_uid": "pharware-sm64-pack",
-    "package_version": "1.2.0",
+    "package_version": "1.2.1",
     "min_poptracker_version": "0.25.5",
     "versions_url": "https://raw.githubusercontent.com/ThePhar/APSM64TrackerPack/main/versions.json",
     "author": "Phar",

--- a/pack_root/scripts/logic/stages/bob.lua
+++ b/pack_root/scripts/logic/stages/bob.lua
@@ -11,7 +11,7 @@ end
 function CanAccessBOBWings()
     return GetAccessibility({
         (HasCannon(course) and HasCap("WC")),
-        (math.min(StrictCannonAccessibilityLevel(), StrictCapAccessibilityLevel())),
+        (HasCannon(course) and StrictCapAccessibilityLevel()),
     })
 end
 

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,14 @@
 {
     "versions": [
         {
+            "package_version": "1.2.1",
+            "download_url": "https://github.com/ThePhar/APSM64TrackerPack/releases/download/1.2.1/PharAPSM64_1.2.1.zip",
+            "sha256": "0cfa30f73fc28ed6a1dd1b8fcbfbfd06653410f86507085b3141218e6d7de1f4",
+            "changelog": [
+                "Fix logic issue with Mario Wings to the Sky not requiring cannon."
+            ]
+        },
+        {
             "package_version": "1.2.0",
             "download_url": "https://github.com/ThePhar/APSM64TrackerPack/releases/download/1.2.0/PharAPSM64_1.2.0.zip",
             "sha256": "8778249df2c491908c83099e7dae6a8e59c96824b061752a623ec2b3559d52fc",


### PR DESCRIPTION
Accidentally wrote that cannon was optional with non-strict caps, instead of required with non-strict caps.